### PR TITLE
Ajusta mensagens de erro e amplia cobertura dos testes de produto

### DIFF
--- a/src/main/java/com/curso/services/ProdutoService.java
+++ b/src/main/java/com/curso/services/ProdutoService.java
@@ -70,7 +70,7 @@ public class ProdutoService {
 
         // valida existência do grupo para erro claro
         if (!grupoProdutoRepo.existsById(grupoId)) {
-            throw new ObjectNotFoundException("Grupo do produto não encontrado: id=" + grupoId);
+            throw new ObjectNotFoundException("Grupo de Produto não encontrado: id=" + grupoId);
         }
 
         // ✅ trate unpaged aqui
@@ -118,7 +118,7 @@ public class ProdutoService {
         return produtoRepo.findByCodigoBarra(normalizedCodigoBarra)
                 .map(ProdutoMapper::toDto)
                 .orElseThrow(() ->
-                        new ObjectNotFoundException("Produto não encontrado: Codigo de Barra=" + normalizedCodigoBarra));
+                        new ObjectNotFoundException("Produto não encontrado: codigoBarra=" + normalizedCodigoBarra));
     }
 
     @Transactional

--- a/src/test/java/com/curso/resources/ProdutoResourceIntegrationTest.java
+++ b/src/test/java/com/curso/resources/ProdutoResourceIntegrationTest.java
@@ -109,6 +109,63 @@ class ProdutoResourceIntegrationTest {
     }
 
     @Test
+    @DisplayName("GET /api/produto com grupoId deve retornar somente produtos do grupo informado")
+    void deveListarProdutosFiltradosPorGrupoComPaginacao() throws Exception {
+        GrupoProduto perifericos = new GrupoProduto();
+        perifericos.setDescricao("Periféricos");
+        perifericos.setStatus(Status.ATIVO);
+        perifericos = grupoProdutoRepository.save(perifericos);
+
+        Produto teclado = new Produto();
+        teclado.setDescricao("Teclado Mecânico");
+        teclado.setCodigoBarra("3216549870123");
+        teclado.setGrupoProduto(perifericos);
+        teclado.setStatus(Status.ATIVO);
+        teclado.setSaldoEstoque(new BigDecimal("4.000"));
+        teclado.setValorUnitario(new BigDecimal("299.90"));
+        Produto produtoTeclado = produtoRepository.save(teclado);
+
+        mockMvc.perform(get("/api/produto")
+                        .param("grupoId", perifericos.getId().toString())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.content[0].idProduto").value(produtoTeclado.getIdProduto()))
+                .andExpect(jsonPath("$.content[0].descricao").value("Teclado Mecânico"))
+                .andExpect(jsonPath("$.content[0].codigoBarra").value("3216549870123"))
+                .andExpect(jsonPath("$.content[0].grupoProdutoId").value(perifericos.getId()))
+                .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    @Test
+    @DisplayName("GET /api/produto/all com grupoId deve retornar lista filtrada pelo grupo")
+    void deveListarProdutosFiltradosPorGrupoSemPaginacao() throws Exception {
+        GrupoProduto acessorios = new GrupoProduto();
+        acessorios.setDescricao("Acessórios");
+        acessorios.setStatus(Status.ATIVO);
+        acessorios = grupoProdutoRepository.save(acessorios);
+
+        Produto mouse = new Produto();
+        mouse.setDescricao("Mouse Sem Fio");
+        mouse.setCodigoBarra("6549873210123");
+        mouse.setGrupoProduto(acessorios);
+        mouse.setStatus(Status.ATIVO);
+        mouse.setSaldoEstoque(new BigDecimal("6.000"));
+        mouse.setValorUnitario(new BigDecimal("149.90"));
+        Produto produtoMouse = produtoRepository.save(mouse);
+
+        mockMvc.perform(get("/api/produto/all")
+                        .param("grupoId", acessorios.getId().toString())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].idProduto").value(produtoMouse.getIdProduto()))
+                .andExpect(jsonPath("$[0].descricao").value("Mouse Sem Fio"))
+                .andExpect(jsonPath("$[0].codigoBarra").value("6549873210123"))
+                .andExpect(jsonPath("$[0].grupoProdutoId").value(acessorios.getId()));
+    }
+
+    @Test
     @DisplayName("GET /api/produto/{id} deve retornar o produto correspondente")
     void deveBuscarProdutoPorId() throws Exception {
         mockMvc.perform(get("/api/produto/{id}", produtoCaboHdmi.getIdProduto())

--- a/src/test/java/com/curso/services/GrupoProdutoServiceUnitTest.java
+++ b/src/test/java/com/curso/services/GrupoProdutoServiceUnitTest.java
@@ -17,6 +17,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -41,6 +42,34 @@ class GrupoProdutoServiceUnitTest {
     void setUp() {
         // Ajuste este construtor se seu service tiver assinatura diferente
         service = new GrupoProdutoService(grupoProdutoRepository, produtoRepository);
+    }
+
+    @Test
+    @DisplayName("findAll deve retornar lista de DTOs mapeada do repositório")
+    void deveListarTodosOsGrupos() {
+        GrupoProduto g1 = new GrupoProduto();
+        g1.setId(1);
+        g1.setDescricao("Bebidas");
+        g1.setStatus(Status.ATIVO);
+
+        GrupoProduto g2 = new GrupoProduto();
+        g2.setId(2);
+        g2.setDescricao("Higiene");
+        g2.setStatus(Status.INATIVO);
+
+        when(grupoProdutoRepository.findAll()).thenReturn(List.of(g1, g2));
+
+        List<GrupoProdutoDTO> result = service.findAll();
+
+        assertAll(
+                () -> assertEquals(2, result.size()),
+                () -> assertEquals(g1.getId(), result.get(0).getId()),
+                () -> assertEquals(g1.getDescricao(), result.get(0).getDescricao()),
+                () -> assertEquals(g1.getStatus().getId(), result.get(0).getStatus()),
+                () -> assertEquals(g2.getId(), result.get(1).getId()),
+                () -> assertEquals(g2.getDescricao(), result.get(1).getDescricao()),
+                () -> assertEquals(g2.getStatus().getId(), result.get(1).getStatus())
+        );
     }
 
     // =======================


### PR DESCRIPTION
## Summary
- alinhei a mensagem de erro de busca de produtos por grupo e por código de barras com asserções existentes
- acrescentei cenários de integração que exercitam os filtros por grupo nos endpoints paginado e não paginado de produtos
- adicionei um teste unitário que garante o comportamento de `GrupoProdutoService.findAll`

## Testing
- ./mvnw test *(falha ao baixar dependências do Maven Wrapper por restrição de rede)*

------
https://chatgpt.com/codex/tasks/task_e_68d33f63d8808329b21a9b1444e26e6a